### PR TITLE
Makefile.am: Added libbbexample dependency to fix parallel build bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,21 @@
+# Autotools generated files
+/Makefile.in
+/autom4te.cache
+/autoscan.log
+/autoscan-*.log
+/aclocal.m4
+/compile
+/config.guess
+/config.h.in
+/config.sub
+/configure
+/configure.scan
+/depcomp
+/install-sh
+/ltmain.sh
+/missing
+/stamp-h1
+
 # Object files
 *.o
 *.ko
@@ -21,3 +39,7 @@
 *.i*86
 *.x86_64
 *.hex
+
+# Yocto devtool temp folders
+/oe-logs
+/oe-workdir

--- a/Makefile.am
+++ b/Makefile.am
@@ -10,3 +10,4 @@ libbbexample_la_LDFLAGS= -version-info 1:0:0
 bin_PROGRAMS = bbexample
 bbexample_SOURCES = bbexample.c
 bbexample_LDADD = .libs/libbbexample.la
+bbexample_DEPENDENCIES = libbbexample.la


### PR DESCRIPTION
This fix removes need for clearing PARALLEL_MAKE variable in bbexample bitbake recipe found in https://github.com/DynamicDevices/meta-example
